### PR TITLE
Fixed cgo pointer problem, and other minor fixes.

### DIFF
--- a/cl/context.go
+++ b/cl/context.go
@@ -194,7 +194,7 @@ func (c *Context) NewProgramFromSource(prog []byte) (*Program, error) {
 	var c_program C.cl_program
 	var err C.cl_int
 
-	srcPtr := (*C.char)(unsafe.Pointer(&prog[0]))
+	srcPtr := C.CString(string(prog)) // (*C.char)(unsafe.Pointer(&prog[0]))
 	length := (C.size_t)(len(prog))
 	if c_program = C.clCreateProgramWithSource(c.id, 1, &srcPtr, &length, &err); err != C.CL_SUCCESS {
 		return nil, Cl_error(err)

--- a/cl/kernel.go
+++ b/cl/kernel.go
@@ -34,9 +34,7 @@ package cl
 */
 import "C"
 
-import (
-	"unsafe"
-)
+import "unsafe"
 
 type KernelProperty C.cl_kernel_info
 
@@ -177,11 +175,14 @@ func (k *Kernel) SetArg(index uint, arg interface{}) error {
 
 	switch t := arg.(type) {
 	case *Buffer:
-		ret = C.clSetKernelArg(k.id, C.cl_uint(index), C.size_t(unsafe.Sizeof(t.id)), unsafe.Pointer(&t.id))
+		tPtr := t.id
+		ret = C.clSetKernelArg(k.id, C.cl_uint(index), C.size_t(unsafe.Sizeof(t.id)), unsafe.Pointer(&tPtr))
 	case *Image:
-		ret = C.clSetKernelArg(k.id, C.cl_uint(index), C.size_t(unsafe.Sizeof(t.id)), unsafe.Pointer(&t.id))
+		tPtr := t.id
+		ret = C.clSetKernelArg(k.id, C.cl_uint(index), C.size_t(unsafe.Sizeof(t.id)), unsafe.Pointer(&tPtr))
 	case *Sampler:
-		ret = C.clSetKernelArg(k.id, C.cl_uint(index), C.size_t(unsafe.Sizeof(t.id)), unsafe.Pointer(&t.id))
+		tPtr := t.id
+		ret = C.clSetKernelArg(k.id, C.cl_uint(index), C.size_t(unsafe.Sizeof(t.id)), unsafe.Pointer(&tPtr))
 	case int32:
 		f := C.int(t)
 		ret = C.clSetKernelArg(k.id, C.cl_uint(index), C.size_t(unsafe.Sizeof(f)), unsafe.Pointer(&f))

--- a/cl/vectAdd_test.go
+++ b/cl/vectAdd_test.go
@@ -22,7 +22,7 @@ package cl
 import (
 	"testing"
 
-	"github.com/pseudomind/go-opencl/raw"
+	"github.com/mathuin/go-opencl/raw"
 )
 
 func Test_VectAdd(t *testing.T) {

--- a/examples/clinfo/clinfo.go
+++ b/examples/clinfo/clinfo.go
@@ -19,7 +19,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/pseudomind/go-opencl/cl"
+	"github.com/mathuin/go-opencl/cl"
 )
 
 func main() {

--- a/examples/rotate/rotate.go
+++ b/examples/rotate/rotate.go
@@ -20,14 +20,15 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/pseudomind/go-opencl/cl"
-	"github.com/pseudomind/go-opencl/raw"
 	"image"
 	"image/jpeg"
 	"image/png"
 	"io"
 	"math"
 	"os"
+
+	"github.com/mathuin/go-opencl/cl"
+	"github.com/mathuin/go-opencl/raw"
 )
 
 var (


### PR DESCRIPTION
Go 1.6 enforces pointer rules with cgo, so some fixes were required.

Also, some files referenced upstream so they were fixed.